### PR TITLE
Updated vendor name

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) Redberry <revaz@redberry.ge>
+Copyright (c) RedberryProducts <revaz@redberry.ge>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) RedberryProducts <revaz@redberry.ge>
+Copyright (c) Redberry <revaz@redberry.ge>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Read your notion pages as Markdown in Laravel applications
 Example:
 
 ```php
-use RedberryProducts\MdNotion\Facades\MdNotion;
+use Redberry\MdNotion\Facades\MdNotion;
 
 $pageId = '263d9316605a806f9e95e1377a46ff3e';
 
@@ -77,8 +77,8 @@ return [
      * Customize these to use your own adapters.
      */
     'adapters' => [
-        'paragraph' => \RedberryProducts\MdNotion\Adapters\ParagraphAdapter::class,
-        'heading_1' => \RedberryProducts\MdNotion\Adapters\HeadingAdapter::class,
+        'paragraph' => \Redberry\MdNotion\Adapters\ParagraphAdapter::class,
+        'heading_1' => \Redberry\MdNotion\Adapters\HeadingAdapter::class,
         // ... many more block adapters
     ],
 ];
@@ -123,7 +123,7 @@ To get your Notion API key:
 Get the content of a single page as markdown:
 
 ```php
-use RedberryProducts\MdNotion\Facades\MdNotion;
+use Redberry\MdNotion\Facades\MdNotion;
 
 $pageId = '263d9316605a806f9e95e1377a46ff3e';
 $content = MdNotion::make($pageId)->content()->read();
@@ -230,7 +230,7 @@ The `MdNotion` package provides rich object models for working with Notion pages
 #### Basic Properties and Methods
 
 ```php
-use RedberryProducts\MdNotion\Objects\Page;
+use Redberry\MdNotion\Objects\Page;
 
 // Create from data
 $page = Page::from([
@@ -279,7 +279,7 @@ $updatedPage = $originalPage->fetch();
 #### Basic Properties and Methods
 
 ```php
-use RedberryProducts\MdNotion\Objects\Database;
+use Redberry\MdNotion\Objects\Database;
 
 // Create from data
 $database = Database::from([
@@ -507,7 +507,7 @@ You will need adapter class extending `src\Adapters\BaseBlockAdapter.php` and cu
 
 namespace App\Adapters;
 
-use RedberryProducts\MdNotion\Adapters\BaseBlockAdapter;
+use Redberry\MdNotion\Adapters\BaseBlockAdapter;
 
 class CustomCodeAdapter extends BaseBlockAdapter
 {
@@ -550,8 +550,8 @@ return [
     'adapters' => [
         'callout' => \App\Adapters\CustomCalloutAdapter::class,
         // Keep existing adapters...
-        'paragraph' => \RedberryProducts\MdNotion\Adapters\ParagraphAdapter::class,
-        'heading_1' => \RedberryProducts\MdNotion\Adapters\HeadingAdapter::class,
+        'paragraph' => \Redberry\MdNotion\Adapters\ParagraphAdapter::class,
+        'heading_1' => \Redberry\MdNotion\Adapters\HeadingAdapter::class,
         // ... other adapters
     ],
 ];

--- a/column-list-fetch-example.php
+++ b/column-list-fetch-example.php
@@ -12,7 +12,7 @@ use Illuminate\View\Engines\CompilerEngine;
 use Illuminate\View\Engines\EngineResolver;
 use Illuminate\View\Factory;
 use Illuminate\View\FileViewFinder;
-use RedberryProducts\MdNotion\Adapters\ColumnListAdapter;
+use Redberry\MdNotion\Adapters\ColumnListAdapter;
 
 // Set up Laravel container
 $container = new Container;
@@ -56,7 +56,7 @@ $factory = new Factory(
 // Bind view factory to container
 $container->instance('view', $factory);
 View::setFacadeApplication($container);
-use RedberryProducts\MdNotion\SDK\Notion;
+use Redberry\MdNotion\SDK\Notion;
 
 // Use actual block ID from Notion
 $columnListBlock = [

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "redberry/md-notion",
     "description": "Read your notion pages as Markdown in Laravel applications.",
     "keywords": [
-        "RedberryProducts",
+        "Redberry",
         "laravel",
         "md-notion"
     ],
@@ -31,12 +31,12 @@
     },
     "autoload": {
         "psr-4": {
-            "RedberryProducts\\MdNotion\\": "src/"
+            "Redberry\\MdNotion\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "RedberryProducts\\MdNotion\\Tests\\": "tests/",
+            "Redberry\\MdNotion\\Tests\\": "tests/",
             "Workbench\\App\\": "workbench/app/"
         }
     },
@@ -57,10 +57,10 @@
     "extra": {
         "laravel": {
             "providers": [
-                "RedberryProducts\\MdNotion\\MdNotionServiceProvider"
+                "Redberry\\MdNotion\\MdNotionServiceProvider"
             ],
             "aliases": {
-                "MdNotion": "RedberryProducts\\MdNotion\\Facades\\MdNotion"
+                "MdNotion": "Redberry\\MdNotion\\Facades\\MdNotion"
             }
         }
     },

--- a/config/md-notion.php
+++ b/config/md-notion.php
@@ -33,7 +33,7 @@ return [
         'heading_3' => \Redberry\MdNotion\Adapters\HeadingAdapter::class,
         'bulleted_list_item' => \Redberry\MdNotion\Adapters\BulletedListItemAdapter::class,
         'numbered_list_item' => \Redberry\MdNotion\Adapters\NumberedListItemAdapter::class,
-        'to_do' => \Redberry\MdNotion\Adapters\TodoAdapter::class,
+        'to_do' => \Redberry\MdNotion\Adapters\ToDoAdapter::class,
         'toggle' => \Redberry\MdNotion\Adapters\ToggleAdapter::class,
         'code' => \Redberry\MdNotion\Adapters\CodeAdapter::class,
         'quote' => \Redberry\MdNotion\Adapters\QuoteAdapter::class,

--- a/config/md-notion.php
+++ b/config/md-notion.php
@@ -1,6 +1,6 @@
 <?php
 
-// config for RedberryProducts/MdNotion
+// config for Redberry/MdNotion
 return [
 
     /**
@@ -27,25 +27,25 @@ return [
      * Values are fully qualified adapter class names.
      */
     'adapters' => [
-        'paragraph' => \RedberryProducts\MdNotion\Adapters\ParagraphAdapter::class,
-        'heading_1' => \RedberryProducts\MdNotion\Adapters\HeadingAdapter::class,
-        'heading_2' => \RedberryProducts\MdNotion\Adapters\HeadingAdapter::class,
-        'heading_3' => \RedberryProducts\MdNotion\Adapters\HeadingAdapter::class,
-        'bulleted_list_item' => \RedberryProducts\MdNotion\Adapters\BulletedListItemAdapter::class,
-        'numbered_list_item' => \RedberryProducts\MdNotion\Adapters\NumberedListItemAdapter::class,
-        'to_do' => \RedberryProducts\MdNotion\Adapters\ToDoAdapter::class,
-        'toggle' => \RedberryProducts\MdNotion\Adapters\ToggleAdapter::class,
-        'code' => \RedberryProducts\MdNotion\Adapters\CodeAdapter::class,
-        'quote' => \RedberryProducts\MdNotion\Adapters\QuoteAdapter::class,
-        'callout' => \RedberryProducts\MdNotion\Adapters\CalloutAdapter::class,
-        'divider' => \RedberryProducts\MdNotion\Adapters\DividerAdapter::class,
-        'bookmark' => \RedberryProducts\MdNotion\Adapters\BookmarkAdapter::class,
-        'image' => \RedberryProducts\MdNotion\Adapters\ImageAdapter::class,
-        'file' => \RedberryProducts\MdNotion\Adapters\FileAdapter::class,
-        'video' => \RedberryProducts\MdNotion\Adapters\VideoAdapter::class,
-        'column_list' => \RedberryProducts\MdNotion\Adapters\ColumnListAdapter::class,
-        'column' => \RedberryProducts\MdNotion\Adapters\ColumnAdapter::class,
-        'table' => \RedberryProducts\MdNotion\Adapters\TableAdapter::class,
-        'table_row' => \RedberryProducts\MdNotion\Adapters\TableRowAdapter::class,
+        'paragraph' => \Redberry\MdNotion\Adapters\ParagraphAdapter::class,
+        'heading_1' => \Redberry\MdNotion\Adapters\HeadingAdapter::class,
+        'heading_2' => \Redberry\MdNotion\Adapters\HeadingAdapter::class,
+        'heading_3' => \Redberry\MdNotion\Adapters\HeadingAdapter::class,
+        'bulleted_list_item' => \Redberry\MdNotion\Adapters\BulletedListItemAdapter::class,
+        'numbered_list_item' => \Redberry\MdNotion\Adapters\NumberedListItemAdapter::class,
+        'to_do' => \Redberry\MdNotion\Adapters\ToDoAdapter::class,
+        'toggle' => \Redberry\MdNotion\Adapters\ToggleAdapter::class,
+        'code' => \Redberry\MdNotion\Adapters\CodeAdapter::class,
+        'quote' => \Redberry\MdNotion\Adapters\QuoteAdapter::class,
+        'callout' => \Redberry\MdNotion\Adapters\CalloutAdapter::class,
+        'divider' => \Redberry\MdNotion\Adapters\DividerAdapter::class,
+        'bookmark' => \Redberry\MdNotion\Adapters\BookmarkAdapter::class,
+        'image' => \Redberry\MdNotion\Adapters\ImageAdapter::class,
+        'file' => \Redberry\MdNotion\Adapters\FileAdapter::class,
+        'video' => \Redberry\MdNotion\Adapters\VideoAdapter::class,
+        'column_list' => \Redberry\MdNotion\Adapters\ColumnListAdapter::class,
+        'column' => \Redberry\MdNotion\Adapters\ColumnAdapter::class,
+        'table' => \Redberry\MdNotion\Adapters\TableAdapter::class,
+        'table_row' => \Redberry\MdNotion\Adapters\TableRowAdapter::class,
     ],
 ];

--- a/config/md-notion.php
+++ b/config/md-notion.php
@@ -33,7 +33,7 @@ return [
         'heading_3' => \Redberry\MdNotion\Adapters\HeadingAdapter::class,
         'bulleted_list_item' => \Redberry\MdNotion\Adapters\BulletedListItemAdapter::class,
         'numbered_list_item' => \Redberry\MdNotion\Adapters\NumberedListItemAdapter::class,
-        'to_do' => \Redberry\MdNotion\Adapters\ToDoAdapter::class,
+        'to_do' => \Redberry\MdNotion\Adapters\TodoAdapter::class,
         'toggle' => \Redberry\MdNotion\Adapters\ToggleAdapter::class,
         'code' => \Redberry\MdNotion\Adapters\CodeAdapter::class,
         'quote' => \Redberry\MdNotion\Adapters\QuoteAdapter::class,

--- a/examples/mdnotion-facade-full-example.php
+++ b/examples/mdnotion-facade-full-example.php
@@ -23,9 +23,9 @@ use Illuminate\View\Engines\CompilerEngine;
 use Illuminate\View\Engines\EngineResolver;
 use Illuminate\View\Factory;
 use Illuminate\View\FileViewFinder;
-use RedberryProducts\MdNotion\Facades\MdNotion;
-use RedberryProducts\MdNotion\MdNotionServiceProvider;
-use RedberryProducts\MdNotion\SDK\Notion;
+use Redberry\MdNotion\Facades\MdNotion;
+use Redberry\MdNotion\MdNotionServiceProvider;
+use Redberry\MdNotion\SDK\Notion;
 
 // Set up Laravel container
 $container = new Container;

--- a/examples/mdnotion-facade-read-example.php
+++ b/examples/mdnotion-facade-read-example.php
@@ -23,9 +23,9 @@ use Illuminate\View\Engines\CompilerEngine;
 use Illuminate\View\Engines\EngineResolver;
 use Illuminate\View\Factory;
 use Illuminate\View\FileViewFinder;
-use RedberryProducts\MdNotion\Facades\MdNotion;
-use RedberryProducts\MdNotion\MdNotionServiceProvider;
-use RedberryProducts\MdNotion\SDK\Notion;
+use Redberry\MdNotion\Facades\MdNotion;
+use Redberry\MdNotion\MdNotionServiceProvider;
+use Redberry\MdNotion\SDK\Notion;
 
 // Set up Laravel container
 $container = new Container;

--- a/examples/page-reader-example.php
+++ b/examples/page-reader-example.php
@@ -12,12 +12,12 @@ use Illuminate\View\Engines\CompilerEngine;
 use Illuminate\View\Engines\EngineResolver;
 use Illuminate\View\Factory;
 use Illuminate\View\FileViewFinder;
-use RedberryProducts\MdNotion\Adapters\BlockAdapterFactory;
-use RedberryProducts\MdNotion\SDK\Notion;
-use RedberryProducts\MdNotion\Services\BlockRegistry;
-use RedberryProducts\MdNotion\Services\DatabaseReader;
-use RedberryProducts\MdNotion\Services\DatabaseTable;
-use RedberryProducts\MdNotion\Services\PageReader;
+use Redberry\MdNotion\Adapters\BlockAdapterFactory;
+use Redberry\MdNotion\SDK\Notion;
+use Redberry\MdNotion\Services\BlockRegistry;
+use Redberry\MdNotion\Services\DatabaseReader;
+use Redberry\MdNotion\Services\DatabaseTable;
+use Redberry\MdNotion\Services\PageReader;
 
 // Set up Laravel container
 $container = new Container;

--- a/examples/sdk-example.php
+++ b/examples/sdk-example.php
@@ -2,7 +2,7 @@
 
 require_once __DIR__.'/../vendor/autoload.php';
 
-use RedberryProducts\MdNotion\SDK\Notion;
+use Redberry\MdNotion\SDK\Notion;
 
 $token = include __DIR__.'/../notion-token.php';
 $notion = new Notion($token, '2025-09-03');

--- a/examples/table-fetch-example.php
+++ b/examples/table-fetch-example.php
@@ -12,7 +12,7 @@ use Illuminate\View\Engines\CompilerEngine;
 use Illuminate\View\Engines\EngineResolver;
 use Illuminate\View\Factory;
 use Illuminate\View\FileViewFinder;
-use RedberryProducts\MdNotion\Adapters\TableAdapter;
+use Redberry\MdNotion\Adapters\TableAdapter;
 
 // Set up Laravel container
 $container = new Container;
@@ -56,7 +56,7 @@ $factory = new Factory(
 // Bind view factory to container
 $container->instance('view', $factory);
 View::setFacadeApplication($container);
-use RedberryProducts\MdNotion\SDK\Notion;
+use Redberry\MdNotion\SDK\Notion;
 
 // Load table JSON
 $tableJson = file_get_contents(__DIR__.'/../BlockJsonExamples/TableJson.json');

--- a/examples/toggle-fetch-example.php
+++ b/examples/toggle-fetch-example.php
@@ -12,7 +12,7 @@ use Illuminate\View\Engines\CompilerEngine;
 use Illuminate\View\Engines\EngineResolver;
 use Illuminate\View\Factory;
 use Illuminate\View\FileViewFinder;
-use RedberryProducts\MdNotion\Adapters\ToggleAdapter;
+use Redberry\MdNotion\Adapters\ToggleAdapter;
 
 // Set up Laravel container
 $container = new Container;
@@ -56,7 +56,7 @@ $factory = new Factory(
 // Bind view factory to container
 $container->instance('view', $factory);
 View::setFacadeApplication($container);
-use RedberryProducts\MdNotion\SDK\Notion;
+use Redberry\MdNotion\SDK\Notion;
 
 // Load toggle JSON
 $toggleJson = file_get_contents(__DIR__.'/../BlockJsonExamples/ToggleJson.json');

--- a/index.php
+++ b/index.php
@@ -2,7 +2,7 @@
 
 require_once __DIR__.'/vendor/autoload.php';
 
-use RedberryProducts\MdNotion\SDK\Notion;
+use Redberry\MdNotion\SDK\Notion;
 
 $token = include __DIR__.'/notion-token.php';
 $notion = new Notion($token, '2025-09-03');

--- a/mdnotion_prd.md
+++ b/mdnotion_prd.md
@@ -25,7 +25,7 @@ The mission of MdNotion is to provide Laravel developers with an easy, reliable,
 ## Usage goal
 
 ```php
-use RedberryProducts\Facades\MdNotion;
+use Redberry\Facades\MdNotion;
 
 $pageId = '263d9316605a806f9e95e1377a46ff3e';
 $MdNotion = MdNotion::make($pageId);

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,7 +16,7 @@
     backupStaticProperties="false"
 >
     <testsuites>
-        <testsuite name="RedberryProducts Test Suite">
+        <testsuite name="Redberry Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>

--- a/src/Adapters/BaseBlockAdapter.php
+++ b/src/Adapters/BaseBlockAdapter.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Adapters;
+namespace Redberry\MdNotion\Adapters;
 
 use Illuminate\Support\Facades\View;
-use RedberryProducts\MdNotion\SDK\Notion;
+use Redberry\MdNotion\SDK\Notion;
 
 abstract class BaseBlockAdapter implements BlockAdapterInterface
 {
@@ -101,7 +101,7 @@ abstract class BaseBlockAdapter implements BlockAdapterInterface
     /**
      * Process rich text blocks from Notion
      *
-     * @param  \RedberryProducts\MdNotion\DTOs\RichTextDTO[]  $richText  Array of rich text DTOs
+     * @param  \Redberry\MdNotion\DTOs\RichTextDTO[]  $richText  Array of rich text DTOs
      */
     protected function processRichText(array $richText): string
     {

--- a/src/Adapters/BlockAdapterFactory.php
+++ b/src/Adapters/BlockAdapterFactory.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Adapters;
+namespace Redberry\MdNotion\Adapters;
 
 use Illuminate\Support\Arr;
-use RedberryProducts\MdNotion\SDK\Notion;
+use Redberry\MdNotion\SDK\Notion;
 
 class BlockAdapterFactory
 {

--- a/src/Adapters/BlockAdapterInterface.php
+++ b/src/Adapters/BlockAdapterInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Adapters;
+namespace Redberry\MdNotion\Adapters;
 
 interface BlockAdapterInterface
 {

--- a/src/Adapters/BookmarkAdapter.php
+++ b/src/Adapters/BookmarkAdapter.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Adapters;
+namespace Redberry\MdNotion\Adapters;
 
-use RedberryProducts\MdNotion\DTOs\BookmarkDTO;
+use Redberry\MdNotion\DTOs\BookmarkDTO;
 
 class BookmarkAdapter extends BaseBlockAdapter
 {

--- a/src/Adapters/BulletedListItemAdapter.php
+++ b/src/Adapters/BulletedListItemAdapter.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Adapters;
+namespace Redberry\MdNotion\Adapters;
 
-use RedberryProducts\MdNotion\DTOs\BulletedListItemDTO;
+use Redberry\MdNotion\DTOs\BulletedListItemDTO;
 
 class BulletedListItemAdapter extends BaseBlockAdapter
 {

--- a/src/Adapters/CalloutAdapter.php
+++ b/src/Adapters/CalloutAdapter.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Adapters;
+namespace Redberry\MdNotion\Adapters;
 
-use RedberryProducts\MdNotion\DTOs\CalloutDTO;
+use Redberry\MdNotion\DTOs\CalloutDTO;
 
 class CalloutAdapter extends BaseBlockAdapter
 {

--- a/src/Adapters/CodeAdapter.php
+++ b/src/Adapters/CodeAdapter.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Adapters;
+namespace Redberry\MdNotion\Adapters;
 
-use RedberryProducts\MdNotion\DTOs\CodeDTO;
+use Redberry\MdNotion\DTOs\CodeDTO;
 
 class CodeAdapter extends BaseBlockAdapter
 {

--- a/src/Adapters/ColumnAdapter.php
+++ b/src/Adapters/ColumnAdapter.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Adapters;
+namespace Redberry\MdNotion\Adapters;
 
-use RedberryProducts\MdNotion\DTOs\ColumnDTO;
+use Redberry\MdNotion\DTOs\ColumnDTO;
 
 class ColumnAdapter extends BaseBlockAdapter
 {
@@ -33,12 +33,12 @@ class ColumnAdapter extends BaseBlockAdapter
 
             // Convert snake_case to PascalCase for class name
             $className = str_replace('_', '', ucwords($type, '_'));
-            $adapterClass = '\\RedberryProducts\\MdNotion\\Adapters\\'.$className.'Adapter';
+            $adapterClass = '\\Redberry\\MdNotion\\Adapters\\'.$className.'Adapter';
 
             if (class_exists($adapterClass)) {
                 $adapter = new $adapterClass;
             } else {
-                $adapter = new \RedberryProducts\MdNotion\Adapters\ParagraphAdapter; // Fallback to paragraph
+                $adapter = new \Redberry\MdNotion\Adapters\ParagraphAdapter; // Fallback to paragraph
             }
             $adapter->setSdk($this->sdk);
             $contents[] = trim($adapter->toMarkdown($childBlock));

--- a/src/Adapters/ColumnListAdapter.php
+++ b/src/Adapters/ColumnListAdapter.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Adapters;
+namespace Redberry\MdNotion\Adapters;
 
-use RedberryProducts\MdNotion\DTOs\ColumnListDTO;
+use Redberry\MdNotion\DTOs\ColumnListDTO;
 
 class ColumnListAdapter extends BaseBlockAdapter
 {

--- a/src/Adapters/DividerAdapter.php
+++ b/src/Adapters/DividerAdapter.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Adapters;
+namespace Redberry\MdNotion\Adapters;
 
-use RedberryProducts\MdNotion\DTOs\DividerDTO;
+use Redberry\MdNotion\DTOs\DividerDTO;
 
 class DividerAdapter extends BaseBlockAdapter
 {

--- a/src/Adapters/FileAdapter.php
+++ b/src/Adapters/FileAdapter.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Adapters;
+namespace Redberry\MdNotion\Adapters;
 
-use RedberryProducts\MdNotion\DTOs\FileDTO;
+use Redberry\MdNotion\DTOs\FileDTO;
 
 class FileAdapter extends BaseBlockAdapter
 {

--- a/src/Adapters/HeadingAdapter.php
+++ b/src/Adapters/HeadingAdapter.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Adapters;
+namespace Redberry\MdNotion\Adapters;
 
-use RedberryProducts\MdNotion\DTOs\HeadingDTO;
+use Redberry\MdNotion\DTOs\HeadingDTO;
 
 class HeadingAdapter extends BaseBlockAdapter
 {

--- a/src/Adapters/ImageAdapter.php
+++ b/src/Adapters/ImageAdapter.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Adapters;
+namespace Redberry\MdNotion\Adapters;
 
-use RedberryProducts\MdNotion\DTOs\ImageDTO;
+use Redberry\MdNotion\DTOs\ImageDTO;
 
 class ImageAdapter extends BaseBlockAdapter
 {

--- a/src/Adapters/NumberedListItemAdapter.php
+++ b/src/Adapters/NumberedListItemAdapter.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Adapters;
+namespace Redberry\MdNotion\Adapters;
 
-use RedberryProducts\MdNotion\DTOs\NumberedListItemDTO;
+use Redberry\MdNotion\DTOs\NumberedListItemDTO;
 
 class NumberedListItemAdapter extends BaseBlockAdapter
 {

--- a/src/Adapters/ParagraphAdapter.php
+++ b/src/Adapters/ParagraphAdapter.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Adapters;
+namespace Redberry\MdNotion\Adapters;
 
-use RedberryProducts\MdNotion\DTOs\ParagraphDTO;
+use Redberry\MdNotion\DTOs\ParagraphDTO;
 
 class ParagraphAdapter extends BaseBlockAdapter
 {

--- a/src/Adapters/QuoteAdapter.php
+++ b/src/Adapters/QuoteAdapter.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Adapters;
+namespace Redberry\MdNotion\Adapters;
 
-use RedberryProducts\MdNotion\DTOs\QuoteDTO;
+use Redberry\MdNotion\DTOs\QuoteDTO;
 
 class QuoteAdapter extends BaseBlockAdapter
 {

--- a/src/Adapters/TableAdapter.php
+++ b/src/Adapters/TableAdapter.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Adapters;
+namespace Redberry\MdNotion\Adapters;
 
-use RedberryProducts\MdNotion\DTOs\TableDTO;
+use Redberry\MdNotion\DTOs\TableDTO;
 
 class TableAdapter extends BaseBlockAdapter
 {

--- a/src/Adapters/TableRowAdapter.php
+++ b/src/Adapters/TableRowAdapter.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Adapters;
+namespace Redberry\MdNotion\Adapters;
 
-use RedberryProducts\MdNotion\DTOs\RichTextDTO;
-use RedberryProducts\MdNotion\DTOs\TableRowDTO;
+use Redberry\MdNotion\DTOs\RichTextDTO;
+use Redberry\MdNotion\DTOs\TableRowDTO;
 
 class TableRowAdapter extends BaseBlockAdapter
 {

--- a/src/Adapters/ToDoAdapter.php
+++ b/src/Adapters/ToDoAdapter.php
@@ -4,7 +4,7 @@ namespace Redberry\MdNotion\Adapters;
 
 use Redberry\MdNotion\DTOs\TodoDTO;
 
-class TodoAdapter extends BaseBlockAdapter
+class ToDoAdapter extends BaseBlockAdapter
 {
     public function getType(): string
     {

--- a/src/Adapters/TodoAdapter.php
+++ b/src/Adapters/TodoAdapter.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Adapters;
+namespace Redberry\MdNotion\Adapters;
 
-use RedberryProducts\MdNotion\DTOs\TodoDTO;
+use Redberry\MdNotion\DTOs\TodoDTO;
 
 class TodoAdapter extends BaseBlockAdapter
 {

--- a/src/Adapters/ToggleAdapter.php
+++ b/src/Adapters/ToggleAdapter.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Adapters;
+namespace Redberry\MdNotion\Adapters;
 
-use RedberryProducts\MdNotion\DTOs\ToggleDTO;
+use Redberry\MdNotion\DTOs\ToggleDTO;
 
 class ToggleAdapter extends BaseBlockAdapter
 {
@@ -32,7 +32,7 @@ class ToggleAdapter extends BaseBlockAdapter
         foreach ($contentBlocks['results'] as $childBlock) {
             // Create adapter based on block type
             $type = $childBlock['type'];
-            $adapterClass = '\\RedberryProducts\\MdNotion\\Adapters\\'.ucfirst($type).'Adapter';
+            $adapterClass = '\\Redberry\\MdNotion\\Adapters\\'.ucfirst($type).'Adapter';
             if (class_exists($adapterClass)) {
                 $adapter = new $adapterClass;
             } else {

--- a/src/Adapters/ToggleAdapter.php
+++ b/src/Adapters/ToggleAdapter.php
@@ -32,7 +32,8 @@ class ToggleAdapter extends BaseBlockAdapter
         foreach ($contentBlocks['results'] as $childBlock) {
             // Create adapter based on block type
             $type = $childBlock['type'];
-            $adapterClass = '\\Redberry\\MdNotion\\Adapters\\'.ucfirst($type).'Adapter';
+            $className = str_replace('_', '', ucwords($type, '_'));
+            $adapterClass = '\\Redberry\\MdNotion\\Adapters\\' . $className . 'Adapter';
             if (class_exists($adapterClass)) {
                 $adapter = new $adapterClass;
             } else {

--- a/src/Adapters/ToggleAdapter.php
+++ b/src/Adapters/ToggleAdapter.php
@@ -33,7 +33,7 @@ class ToggleAdapter extends BaseBlockAdapter
             // Create adapter based on block type
             $type = $childBlock['type'];
             $className = str_replace('_', '', ucwords($type, '_'));
-            $adapterClass = '\\Redberry\\MdNotion\\Adapters\\' . $className . 'Adapter';
+            $adapterClass = '\\Redberry\\MdNotion\\Adapters\\'.$className.'Adapter';
             if (class_exists($adapterClass)) {
                 $adapter = new $adapterClass;
             } else {

--- a/src/Adapters/VideoAdapter.php
+++ b/src/Adapters/VideoAdapter.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Adapters;
+namespace Redberry\MdNotion\Adapters;
 
-use RedberryProducts\MdNotion\DTOs\VideoDTO;
+use Redberry\MdNotion\DTOs\VideoDTO;
 
 class VideoAdapter extends BaseBlockAdapter
 {

--- a/src/Commands/MdNotionCommand.php
+++ b/src/Commands/MdNotionCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Commands;
+namespace Redberry\MdNotion\Commands;
 
 use Illuminate\Console\Command;
 

--- a/src/ContentBuilder.php
+++ b/src/ContentBuilder.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace RedberryProducts\MdNotion;
+namespace Redberry\MdNotion;
 
-use RedberryProducts\MdNotion\Objects\Page;
-use RedberryProducts\MdNotion\Services\DatabaseReader;
-use RedberryProducts\MdNotion\Services\PageReader;
+use Redberry\MdNotion\Objects\Page;
+use Redberry\MdNotion\Services\DatabaseReader;
+use Redberry\MdNotion\Services\PageReader;
 
 class ContentBuilder
 {

--- a/src/DTOs/BlockDTO.php
+++ b/src/DTOs/BlockDTO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\DTOs;
+namespace Redberry\MdNotion\DTOs;
 
 abstract class BlockDTO
 {

--- a/src/DTOs/BookmarkDTO.php
+++ b/src/DTOs/BookmarkDTO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\DTOs;
+namespace Redberry\MdNotion\DTOs;
 
 class BookmarkDTO extends BlockDTO
 {

--- a/src/DTOs/BulletedListItemDTO.php
+++ b/src/DTOs/BulletedListItemDTO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\DTOs;
+namespace Redberry\MdNotion\DTOs;
 
 class BulletedListItemDTO extends BlockDTO
 {

--- a/src/DTOs/CalloutDTO.php
+++ b/src/DTOs/CalloutDTO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\DTOs;
+namespace Redberry\MdNotion\DTOs;
 
 class CalloutDTO extends BlockDTO
 {

--- a/src/DTOs/CodeDTO.php
+++ b/src/DTOs/CodeDTO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\DTOs;
+namespace Redberry\MdNotion\DTOs;
 
 class CodeDTO extends BlockDTO
 {

--- a/src/DTOs/ColumnDTO.php
+++ b/src/DTOs/ColumnDTO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\DTOs;
+namespace Redberry\MdNotion\DTOs;
 
 class ColumnDTO extends BlockDTO
 {

--- a/src/DTOs/ColumnListDTO.php
+++ b/src/DTOs/ColumnListDTO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\DTOs;
+namespace Redberry\MdNotion\DTOs;
 
 class ColumnListDTO extends BlockDTO
 {

--- a/src/DTOs/DividerDTO.php
+++ b/src/DTOs/DividerDTO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\DTOs;
+namespace Redberry\MdNotion\DTOs;
 
 class DividerDTO extends BlockDTO
 {

--- a/src/DTOs/FileDTO.php
+++ b/src/DTOs/FileDTO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\DTOs;
+namespace Redberry\MdNotion\DTOs;
 
 class FileDTO extends BlockDTO
 {

--- a/src/DTOs/HeadingDTO.php
+++ b/src/DTOs/HeadingDTO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\DTOs;
+namespace Redberry\MdNotion\DTOs;
 
 class HeadingDTO extends BlockDTO
 {

--- a/src/DTOs/ImageDTO.php
+++ b/src/DTOs/ImageDTO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\DTOs;
+namespace Redberry\MdNotion\DTOs;
 
 class ImageDTO extends BlockDTO
 {

--- a/src/DTOs/NumberedListItemDTO.php
+++ b/src/DTOs/NumberedListItemDTO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\DTOs;
+namespace Redberry\MdNotion\DTOs;
 
 class NumberedListItemDTO extends BlockDTO
 {

--- a/src/DTOs/ParagraphDTO.php
+++ b/src/DTOs/ParagraphDTO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\DTOs;
+namespace Redberry\MdNotion\DTOs;
 
 class ParagraphDTO extends BlockDTO
 {

--- a/src/DTOs/QuoteDTO.php
+++ b/src/DTOs/QuoteDTO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\DTOs;
+namespace Redberry\MdNotion\DTOs;
 
 class QuoteDTO extends BlockDTO
 {

--- a/src/DTOs/RichTextDTO.php
+++ b/src/DTOs/RichTextDTO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\DTOs;
+namespace Redberry\MdNotion\DTOs;
 
 class RichTextDTO
 {

--- a/src/DTOs/TableDTO.php
+++ b/src/DTOs/TableDTO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\DTOs;
+namespace Redberry\MdNotion\DTOs;
 
 class TableDTO extends BlockDTO
 {

--- a/src/DTOs/TableRowDTO.php
+++ b/src/DTOs/TableRowDTO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\DTOs;
+namespace Redberry\MdNotion\DTOs;
 
 class TableRowDTO extends BlockDTO
 {

--- a/src/DTOs/TodoDTO.php
+++ b/src/DTOs/TodoDTO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\DTOs;
+namespace Redberry\MdNotion\DTOs;
 
 class TodoDTO extends BlockDTO
 {

--- a/src/DTOs/ToggleDTO.php
+++ b/src/DTOs/ToggleDTO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\DTOs;
+namespace Redberry\MdNotion\DTOs;
 
 class ToggleDTO extends BlockDTO
 {

--- a/src/DTOs/VideoDTO.php
+++ b/src/DTOs/VideoDTO.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\DTOs;
+namespace Redberry\MdNotion\DTOs;
 
 class VideoDTO extends BlockDTO
 {

--- a/src/Facades/MdNotion.php
+++ b/src/Facades/MdNotion.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Facades;
+namespace Redberry\MdNotion\Facades;
 
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @see \RedberryProducts\MdNotion\MdNotion
+ * @see \Redberry\MdNotion\MdNotion
  */
 class MdNotion extends Facade
 {
     protected static function getFacadeAccessor(): string
     {
-        return \RedberryProducts\MdNotion\MdNotion::class;
+        return \Redberry\MdNotion\MdNotion::class;
     }
 }

--- a/src/MdNotion.php
+++ b/src/MdNotion.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace RedberryProducts\MdNotion;
+namespace Redberry\MdNotion;
 
 use Illuminate\Support\Collection;
-use RedberryProducts\MdNotion\Objects\Page;
-use RedberryProducts\MdNotion\Services\DatabaseReader;
-use RedberryProducts\MdNotion\Services\PageReader;
+use Redberry\MdNotion\Objects\Page;
+use Redberry\MdNotion\Services\DatabaseReader;
+use Redberry\MdNotion\Services\PageReader;
 
 class MdNotion
 {

--- a/src/MdNotionServiceProvider.php
+++ b/src/MdNotionServiceProvider.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace RedberryProducts\MdNotion;
+namespace Redberry\MdNotion;
 
-use RedberryProducts\MdNotion\Adapters\BlockAdapterFactory;
-use RedberryProducts\MdNotion\SDK\Notion;
-use RedberryProducts\MdNotion\Services\BlockRegistry;
-use RedberryProducts\MdNotion\Services\DatabaseReader;
-use RedberryProducts\MdNotion\Services\DatabaseTable;
-use RedberryProducts\MdNotion\Services\PageReader;
+use Redberry\MdNotion\Adapters\BlockAdapterFactory;
+use Redberry\MdNotion\SDK\Notion;
+use Redberry\MdNotion\Services\BlockRegistry;
+use Redberry\MdNotion\Services\DatabaseReader;
+use Redberry\MdNotion\Services\DatabaseTable;
+use Redberry\MdNotion\Services\PageReader;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 

--- a/src/Objects/BaseObject.php
+++ b/src/Objects/BaseObject.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Objects;
+namespace Redberry\MdNotion\Objects;
 
-use RedberryProducts\MdNotion\Traits\HasChildPages;
-use RedberryProducts\MdNotion\Traits\HasIcon;
-use RedberryProducts\MdNotion\Traits\HasMeta;
-use RedberryProducts\MdNotion\Traits\HasParent;
-use RedberryProducts\MdNotion\Traits\HasTitle;
+use Redberry\MdNotion\Traits\HasChildPages;
+use Redberry\MdNotion\Traits\HasIcon;
+use Redberry\MdNotion\Traits\HasMeta;
+use Redberry\MdNotion\Traits\HasParent;
+use Redberry\MdNotion\Traits\HasTitle;
 
 abstract class BaseObject
 {

--- a/src/Objects/Database.php
+++ b/src/Objects/Database.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Objects;
+namespace Redberry\MdNotion\Objects;
 
 class Database extends BaseObject
 {
@@ -35,7 +35,7 @@ class Database extends BaseObject
     public function readItemsContent(): static
     {
         if ($this->hasChildPages()) {
-            $pageReader = app(\RedberryProducts\MdNotion\Services\PageReader::class);
+            $pageReader = app(\Redberry\MdNotion\Services\PageReader::class);
             $this->setChildPages(
                 $this->getChildPages()->map(function (Page $page) use ($pageReader) {
                     return $pageReader->read($page->getId());
@@ -77,7 +77,7 @@ class Database extends BaseObject
      */
     public function fetch(): static
     {
-        $databaseReader = app(\RedberryProducts\MdNotion\Services\DatabaseReader::class);
+        $databaseReader = app(\Redberry\MdNotion\Services\DatabaseReader::class);
         $fetchedDatabase = $databaseReader->read($this->getId());
 
         // Copy all data from the fetched database to this instance

--- a/src/Objects/Page.php
+++ b/src/Objects/Page.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Objects;
+namespace Redberry\MdNotion\Objects;
 
 use Illuminate\Support\Collection;
 
@@ -107,7 +107,7 @@ class Page extends BaseObject
     public function readChildPagesContent(): static
     {
         if ($this->hasChildPages()) {
-            $pageReader = app(\RedberryProducts\MdNotion\Services\PageReader::class);
+            $pageReader = app(\Redberry\MdNotion\Services\PageReader::class);
             $this->setChildPages(
                 $this->getChildPages()->map(function (Page $page) use ($pageReader) {
                     return $pageReader->read($page->getId());
@@ -124,7 +124,7 @@ class Page extends BaseObject
     public function readChildDatabasesContent(): static
     {
         if ($this->hasChildDatabases()) {
-            $databaseReader = app(\RedberryProducts\MdNotion\Services\DatabaseReader::class);
+            $databaseReader = app(\Redberry\MdNotion\Services\DatabaseReader::class);
             $this->setChildDatabases(
                 $this->getChildDatabases()->map(function (Database $database) use ($databaseReader) {
                     return $databaseReader->read($database->getId());
@@ -161,7 +161,7 @@ class Page extends BaseObject
      */
     public function fetch(): static
     {
-        $pageReader = app(\RedberryProducts\MdNotion\Services\PageReader::class);
+        $pageReader = app(\Redberry\MdNotion\Services\PageReader::class);
         $fetchedPage = $pageReader->read($this->getId());
 
         // Copy all data from the fetched page to this instance

--- a/src/SDK/Notion.php
+++ b/src/SDK/Notion.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace RedberryProducts\MdNotion\SDK;
+namespace Redberry\MdNotion\SDK;
 
-use RedberryProducts\MdNotion\SDK\Resource\Actions;
+use Redberry\MdNotion\SDK\Resource\Actions;
 use Saloon\Http\Auth\TokenAuthenticator;
 use Saloon\Http\Connector;
 

--- a/src/SDK/Requests/Actions/AddCommentToPage.php
+++ b/src/SDK/Requests/Actions/AddCommentToPage.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\SDK\Requests\Actions;
+namespace Redberry\MdNotion\SDK\Requests\Actions;
 
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;

--- a/src/SDK/Requests/Actions/BlockChildren.php
+++ b/src/SDK/Requests/Actions/BlockChildren.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\SDK\Requests\Actions;
+namespace Redberry\MdNotion\SDK\Requests\Actions;
 
 use Saloon\Enums\Method;
 use Saloon\Http\Request;

--- a/src/SDK/Requests/Actions/Database.php
+++ b/src/SDK/Requests/Actions/Database.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\SDK\Requests\Actions;
+namespace Redberry\MdNotion\SDK\Requests\Actions;
 
 use Saloon\Enums\Method;
 use Saloon\Http\Request;

--- a/src/SDK/Requests/Actions/ListComments.php
+++ b/src/SDK/Requests/Actions/ListComments.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\SDK\Requests\Actions;
+namespace Redberry\MdNotion\SDK\Requests\Actions;
 
 use Saloon\Enums\Method;
 use Saloon\Http\Request;

--- a/src/SDK/Requests/Actions/Page.php
+++ b/src/SDK/Requests/Actions/Page.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\SDK\Requests\Actions;
+namespace Redberry\MdNotion\SDK\Requests\Actions;
 
 use Saloon\Enums\Method;
 use Saloon\Http\Request;

--- a/src/SDK/Requests/Actions/QueryDataSource.php
+++ b/src/SDK/Requests/Actions/QueryDataSource.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\SDK\Requests\Actions;
+namespace Redberry\MdNotion\SDK\Requests\Actions;
 
 use Saloon\Enums\Method;
 use Saloon\Http\Request;

--- a/src/SDK/Resource.php
+++ b/src/SDK/Resource.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\SDK;
+namespace Redberry\MdNotion\SDK;
 
 use Saloon\Http\Connector;
 

--- a/src/SDK/Resource/Actions.php
+++ b/src/SDK/Resource/Actions.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace RedberryProducts\MdNotion\SDK\Resource;
+namespace Redberry\MdNotion\SDK\Resource;
 
-use RedberryProducts\MdNotion\SDK\Requests\Actions\AddCommentToPage;
-use RedberryProducts\MdNotion\SDK\Requests\Actions\BlockChildren;
-use RedberryProducts\MdNotion\SDK\Requests\Actions\Database;
-use RedberryProducts\MdNotion\SDK\Requests\Actions\ListComments;
-use RedberryProducts\MdNotion\SDK\Requests\Actions\Page;
-use RedberryProducts\MdNotion\SDK\Requests\Actions\QueryDataSource;
-use RedberryProducts\MdNotion\SDK\Resource;
+use Redberry\MdNotion\SDK\Requests\Actions\AddCommentToPage;
+use Redberry\MdNotion\SDK\Requests\Actions\BlockChildren;
+use Redberry\MdNotion\SDK\Requests\Actions\Database;
+use Redberry\MdNotion\SDK\Requests\Actions\ListComments;
+use Redberry\MdNotion\SDK\Requests\Actions\Page;
+use Redberry\MdNotion\SDK\Requests\Actions\QueryDataSource;
+use Redberry\MdNotion\SDK\Resource;
 use Saloon\Http\Response;
 
 class Actions extends Resource

--- a/src/Services/BlockRegistry.php
+++ b/src/Services/BlockRegistry.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Services;
+namespace Redberry\MdNotion\Services;
 
-use RedberryProducts\MdNotion\Adapters\BlockAdapterFactory;
-use RedberryProducts\MdNotion\Adapters\BlockAdapterInterface;
+use Redberry\MdNotion\Adapters\BlockAdapterFactory;
+use Redberry\MdNotion\Adapters\BlockAdapterInterface;
 
 class BlockRegistry
 {

--- a/src/Services/DatabaseReader.php
+++ b/src/Services/DatabaseReader.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Services;
+namespace Redberry\MdNotion\Services;
 
 use Illuminate\Support\Collection;
-use RedberryProducts\MdNotion\Objects\Database;
-use RedberryProducts\MdNotion\Objects\Page;
-use RedberryProducts\MdNotion\SDK\Notion;
+use Redberry\MdNotion\Objects\Database;
+use Redberry\MdNotion\Objects\Page;
+use Redberry\MdNotion\SDK\Notion;
 
 class DatabaseReader
 {

--- a/src/Services/DatabaseTable.php
+++ b/src/Services/DatabaseTable.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Services;
+namespace Redberry\MdNotion\Services;
 
 class DatabaseTable
 {

--- a/src/Services/PageReader.php
+++ b/src/Services/PageReader.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Services;
+namespace Redberry\MdNotion\Services;
 
-use RedberryProducts\MdNotion\Objects\Database;
-use RedberryProducts\MdNotion\Objects\Page;
-use RedberryProducts\MdNotion\SDK\Notion;
+use Redberry\MdNotion\Objects\Database;
+use Redberry\MdNotion\Objects\Page;
+use Redberry\MdNotion\SDK\Notion;
 
 class PageReader
 {

--- a/src/Traits/HasChildPages.php
+++ b/src/Traits/HasChildPages.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Traits;
+namespace Redberry\MdNotion\Traits;
 
 use Illuminate\Support\Collection;
-use RedberryProducts\MdNotion\Objects\Page;
+use Redberry\MdNotion\Objects\Page;
 
 trait HasChildPages
 {

--- a/src/Traits/HasIcon.php
+++ b/src/Traits/HasIcon.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Traits;
+namespace Redberry\MdNotion\Traits;
 
 trait HasIcon
 {

--- a/src/Traits/HasMeta.php
+++ b/src/Traits/HasMeta.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Traits;
+namespace Redberry\MdNotion\Traits;
 
 trait HasMeta
 {

--- a/src/Traits/HasParent.php
+++ b/src/Traits/HasParent.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Traits;
+namespace Redberry\MdNotion\Traits;
 
 trait HasParent
 {

--- a/src/Traits/HasTitle.php
+++ b/src/Traits/HasTitle.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Traits;
+namespace Redberry\MdNotion\Traits;
 
-use RedberryProducts\MdNotion\DTOs\RichTextDTO;
+use Redberry\MdNotion\DTOs\RichTextDTO;
 
 trait HasTitle
 {

--- a/tests/Adapters/BookmarkAdapterTest.php
+++ b/tests/Adapters/BookmarkAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use RedberryProducts\MdNotion\Adapters\BookmarkAdapter;
+use Redberry\MdNotion\Adapters\BookmarkAdapter;
 
 test('bookmark adapter converts block to markdown', function () {
     $block = [

--- a/tests/Adapters/BulletedListItemAdapterTest.php
+++ b/tests/Adapters/BulletedListItemAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use RedberryProducts\MdNotion\Adapters\BulletedListItemAdapter;
+use Redberry\MdNotion\Adapters\BulletedListItemAdapter;
 
 test('bulleted list item adapter converts block to markdown', function () {
     $block = [

--- a/tests/Adapters/CalloutAdapterTest.php
+++ b/tests/Adapters/CalloutAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use RedberryProducts\MdNotion\Adapters\CalloutAdapter;
+use Redberry\MdNotion\Adapters\CalloutAdapter;
 
 test('callout adapter converts emoji block to markdown', function () {
     $block = [

--- a/tests/Adapters/CodeAdapterTest.php
+++ b/tests/Adapters/CodeAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use RedberryProducts\MdNotion\Adapters\CodeAdapter;
+use Redberry\MdNotion\Adapters\CodeAdapter;
 
 test('code adapter converts code block to markdown', function () {
     $block = [

--- a/tests/Adapters/ColumnAdapterTest.php
+++ b/tests/Adapters/ColumnAdapterTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use RedberryProducts\MdNotion\Adapters\ColumnAdapter;
-use RedberryProducts\MdNotion\DTOs\ColumnDTO;
-use RedberryProducts\MdNotion\SDK\Notion;
+use Redberry\MdNotion\Adapters\ColumnAdapter;
+use Redberry\MdNotion\DTOs\ColumnDTO;
+use Redberry\MdNotion\SDK\Notion;
 
 it('converts column block to markdown', function () {
     // Create mock SDK response for children

--- a/tests/Adapters/ColumnListAdapterTest.php
+++ b/tests/Adapters/ColumnListAdapterTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use RedberryProducts\MdNotion\Adapters\ColumnListAdapter;
-use RedberryProducts\MdNotion\DTOs\ColumnListDTO;
-use RedberryProducts\MdNotion\SDK\Notion;
+use Redberry\MdNotion\Adapters\ColumnListAdapter;
+use Redberry\MdNotion\DTOs\ColumnListDTO;
+use Redberry\MdNotion\SDK\Notion;
 
 it('converts column list block to markdown', function () {
     // Create mock SDK response for columns

--- a/tests/Adapters/DividerAdapterTest.php
+++ b/tests/Adapters/DividerAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use RedberryProducts\MdNotion\Adapters\DividerAdapter;
+use Redberry\MdNotion\Adapters\DividerAdapter;
 
 test('divider adapter converts block to markdown', function () {
     $block = [

--- a/tests/Adapters/FileAdapterTest.php
+++ b/tests/Adapters/FileAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use RedberryProducts\MdNotion\Adapters\FileAdapter;
+use Redberry\MdNotion\Adapters\FileAdapter;
 
 test('file adapter converts basic file block to markdown', function () {
     $block = [

--- a/tests/Adapters/HeadingAdapterTest.php
+++ b/tests/Adapters/HeadingAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use RedberryProducts\MdNotion\Adapters\HeadingAdapter;
+use Redberry\MdNotion\Adapters\HeadingAdapter;
 
 test('heading_1 adapter converts basic block to markdown', function () {
     $block = [

--- a/tests/Adapters/ImageAdapterTest.php
+++ b/tests/Adapters/ImageAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use RedberryProducts\MdNotion\Adapters\ImageAdapter;
+use Redberry\MdNotion\Adapters\ImageAdapter;
 
 test('image adapter converts file type image block to markdown', function () {
     $block = [

--- a/tests/Adapters/NumberedListItemAdapterTest.php
+++ b/tests/Adapters/NumberedListItemAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use RedberryProducts\MdNotion\Adapters\NumberedListItemAdapter;
+use Redberry\MdNotion\Adapters\NumberedListItemAdapter;
 
 test('numbered list item adapter converts basic block to markdown', function () {
     $block = [

--- a/tests/Adapters/ParagraphAdapterTest.php
+++ b/tests/Adapters/ParagraphAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use RedberryProducts\MdNotion\Adapters\ParagraphAdapter;
+use Redberry\MdNotion\Adapters\ParagraphAdapter;
 
 test('paragraph adapter converts block to markdown', function () {
     $block = [

--- a/tests/Adapters/QuoteAdapterTest.php
+++ b/tests/Adapters/QuoteAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use RedberryProducts\MdNotion\Adapters\QuoteAdapter;
+use Redberry\MdNotion\Adapters\QuoteAdapter;
 
 test('quote adapter converts basic block to markdown', function () {
     $block = [

--- a/tests/Adapters/TableAdapterTest.php
+++ b/tests/Adapters/TableAdapterTest.php
@@ -1,8 +1,8 @@
 <?php
 
 use Mockery;
-use RedberryProducts\MdNotion\Adapters\TableAdapter;
-use RedberryProducts\MdNotion\SDK\Notion;
+use Redberry\MdNotion\Adapters\TableAdapter;
+use Redberry\MdNotion\SDK\Notion;
 
 test('table adapter converts basic table to markdown', function () {
     $block = [

--- a/tests/Adapters/TableRowAdapterTest.php
+++ b/tests/Adapters/TableRowAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use RedberryProducts\MdNotion\Adapters\TableRowAdapter;
+use Redberry\MdNotion\Adapters\TableRowAdapter;
 
 test('table row adapter converts basic row to markdown', function () {
     $block = [

--- a/tests/Adapters/ToDoAdapterTest.php
+++ b/tests/Adapters/ToDoAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Redberry\MdNotion\Adapters\TodoAdapter;
+use Redberry\MdNotion\Adapters\ToDoAdapter;
 
 test('todo adapter converts unchecked block to markdown', function () {
     $block = [
@@ -33,7 +33,7 @@ test('todo adapter converts unchecked block to markdown', function () {
         ],
     ];
 
-    $adapter = new TodoAdapter;
+    $adapter = new ToDoAdapter;
     $markdown = $adapter->toMarkdown($block);
 
     expect($markdown)->toBe('- [ ] To do 1');
@@ -70,7 +70,7 @@ test('todo adapter converts checked block to markdown', function () {
         ],
     ];
 
-    $adapter = new TodoAdapter;
+    $adapter = new ToDoAdapter;
     $markdown = $adapter->toMarkdown($block);
 
     expect($markdown)->toBe('- [x] Completed task');
@@ -124,7 +124,7 @@ test('todo adapter handles formatted text', function () {
         ],
     ];
 
-    $adapter = new TodoAdapter;
+    $adapter = new ToDoAdapter;
     $markdown = $adapter->toMarkdown($block);
 
     expect($markdown)->toBe('- [x] **Formatted** _todo item_');

--- a/tests/Adapters/TodoAdapterTest.php
+++ b/tests/Adapters/TodoAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use RedberryProducts\MdNotion\Adapters\TodoAdapter;
+use Redberry\MdNotion\Adapters\TodoAdapter;
 
 test('todo adapter converts unchecked block to markdown', function () {
     $block = [

--- a/tests/Adapters/ToggleAdapterTest.php
+++ b/tests/Adapters/ToggleAdapterTest.php
@@ -1,9 +1,9 @@
 <?php
 
-use RedberryProducts\MdNotion\Adapters\ToggleAdapter;
-use RedberryProducts\MdNotion\DTOs\RichTextDTO;
-use RedberryProducts\MdNotion\DTOs\ToggleDTO;
-use RedberryProducts\MdNotion\SDK\Notion;
+use Redberry\MdNotion\Adapters\ToggleAdapter;
+use Redberry\MdNotion\DTOs\RichTextDTO;
+use Redberry\MdNotion\DTOs\ToggleDTO;
+use Redberry\MdNotion\SDK\Notion;
 
 it('converts toggle block to markdown', function () {
     // Create mock SDK response for children

--- a/tests/Adapters/VideoAdapterTest.php
+++ b/tests/Adapters/VideoAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use RedberryProducts\MdNotion\Adapters\VideoAdapter;
+use Redberry\MdNotion\Adapters\VideoAdapter;
 
 test('video adapter converts external video block to markdown', function () {
     $block = [

--- a/tests/ContentBuilderTest.php
+++ b/tests/ContentBuilderTest.php
@@ -1,9 +1,9 @@
 <?php
 
-use RedberryProducts\MdNotion\ContentBuilder;
-use RedberryProducts\MdNotion\Objects\Page;
-use RedberryProducts\MdNotion\Services\DatabaseReader;
-use RedberryProducts\MdNotion\Services\PageReader;
+use Redberry\MdNotion\ContentBuilder;
+use Redberry\MdNotion\Objects\Page;
+use Redberry\MdNotion\Services\DatabaseReader;
+use Redberry\MdNotion\Services\PageReader;
 
 beforeEach(function () {
     // Mock the PageReader

--- a/tests/FacadeTest.php
+++ b/tests/FacadeTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use RedberryProducts\MdNotion\Facades\MdNotion;
-use RedberryProducts\MdNotion\Objects\Page;
-use RedberryProducts\MdNotion\Services\PageReader;
+use Redberry\MdNotion\Facades\MdNotion;
+use Redberry\MdNotion\Objects\Page;
+use Redberry\MdNotion\Services\PageReader;
 
 beforeEach(function () {
     $this->mockPageReader = Mockery::mock(PageReader::class);
@@ -41,5 +41,5 @@ it('facade returns correct instance type', function () {
 
     $mdNotion = MdNotion::make($pageId);
 
-    expect($mdNotion)->toBeInstanceOf(\RedberryProducts\MdNotion\MdNotion::class);
+    expect($mdNotion)->toBeInstanceOf(\Redberry\MdNotion\MdNotion::class);
 });

--- a/tests/MdNotionTest.php
+++ b/tests/MdNotionTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use RedberryProducts\MdNotion\MdNotion;
-use RedberryProducts\MdNotion\Objects\Database;
-use RedberryProducts\MdNotion\Objects\Page;
-use RedberryProducts\MdNotion\Services\DatabaseReader;
-use RedberryProducts\MdNotion\Services\PageReader;
+use Redberry\MdNotion\MdNotion;
+use Redberry\MdNotion\Objects\Database;
+use Redberry\MdNotion\Objects\Page;
+use Redberry\MdNotion\Services\DatabaseReader;
+use Redberry\MdNotion\Services\PageReader;
 
 beforeEach(function () {
     // Mock the PageReader

--- a/tests/Objects/ContextTest.php
+++ b/tests/Objects/ContextTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use RedberryProducts\MdNotion\Objects\Database;
-use RedberryProducts\MdNotion\Objects\Page;
+use Redberry\MdNotion\Objects\Database;
+use Redberry\MdNotion\Objects\Page;
 
 test('page object can be initialized from block context', function () {
     // Using ChildPageJson.json data

--- a/tests/Objects/DatabaseFetchTest.php
+++ b/tests/Objects/DatabaseFetchTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use RedberryProducts\MdNotion\Objects\Database;
-use RedberryProducts\MdNotion\Services\DatabaseReader;
+use Redberry\MdNotion\Objects\Database;
+use Redberry\MdNotion\Services\DatabaseReader;
 
 beforeEach(function () {
     $this->mockDatabaseReader = Mockery::mock(DatabaseReader::class);

--- a/tests/Objects/IconTest.php
+++ b/tests/Objects/IconTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use RedberryProducts\MdNotion\Objects\Database;
-use RedberryProducts\MdNotion\Objects\Page;
+use Redberry\MdNotion\Objects\Database;
+use Redberry\MdNotion\Objects\Page;
 
 test('page object can handle icon data', function () {
     $pageData = [

--- a/tests/Objects/PageFetchTest.php
+++ b/tests/Objects/PageFetchTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use RedberryProducts\MdNotion\Objects\Page;
-use RedberryProducts\MdNotion\Services\PageReader;
+use Redberry\MdNotion\Objects\Page;
+use Redberry\MdNotion\Services\PageReader;
 
 beforeEach(function () {
     $this->mockPageReader = Mockery::mock(PageReader::class);

--- a/tests/Objects/RenderTitleTest.php
+++ b/tests/Objects/RenderTitleTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use RedberryProducts\MdNotion\Objects\Database;
-use RedberryProducts\MdNotion\Objects\Page;
+use Redberry\MdNotion\Objects\Database;
+use Redberry\MdNotion\Objects\Page;
 
 test('renderTitle generates markdown heading with level 1', function () {
     $page = new Page([

--- a/tests/Objects/TitleTest.php
+++ b/tests/Objects/TitleTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use RedberryProducts\MdNotion\Objects\Database;
-use RedberryProducts\MdNotion\Objects\Page;
+use Redberry\MdNotion\Objects\Database;
+use Redberry\MdNotion\Objects\Page;
 
 test('page object can handle rich text title format', function () {
     $data = [

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,6 +1,6 @@
 <?php
 
-use RedberryProducts\MdNotion\Tests\TestCase;
+use Redberry\MdNotion\Tests\TestCase;
 use Saloon\Http\Faking\MockClient;
 
 uses(TestCase::class)->in(__DIR__);

--- a/tests/SDK/Requests/AddCommentToPageRequestTest.php
+++ b/tests/SDK/Requests/AddCommentToPageRequestTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use RedberryProducts\MdNotion\SDK\Notion;
-use RedberryProducts\MdNotion\SDK\Requests\Actions\AddCommentToPage;
+use Redberry\MdNotion\SDK\Notion;
+use Redberry\MdNotion\SDK\Requests\Actions\AddCommentToPage;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
 

--- a/tests/SDK/Requests/BlockChildrenRequestTest.php
+++ b/tests/SDK/Requests/BlockChildrenRequestTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use RedberryProducts\MdNotion\SDK\Notion;
-use RedberryProducts\MdNotion\SDK\Requests\Actions\BlockChildren;
+use Redberry\MdNotion\SDK\Notion;
+use Redberry\MdNotion\SDK\Requests\Actions\BlockChildren;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
 

--- a/tests/SDK/Requests/DatabaseRequestTest.php
+++ b/tests/SDK/Requests/DatabaseRequestTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use RedberryProducts\MdNotion\SDK\Notion;
-use RedberryProducts\MdNotion\SDK\Requests\Actions\Database;
+use Redberry\MdNotion\SDK\Notion;
+use Redberry\MdNotion\SDK\Requests\Actions\Database;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
 

--- a/tests/SDK/Requests/ListCommentsRequestTest.php
+++ b/tests/SDK/Requests/ListCommentsRequestTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use RedberryProducts\MdNotion\SDK\Notion;
-use RedberryProducts\MdNotion\SDK\Requests\Actions\ListComments;
+use Redberry\MdNotion\SDK\Notion;
+use Redberry\MdNotion\SDK\Requests\Actions\ListComments;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
 

--- a/tests/SDK/Requests/PageRequestTest.php
+++ b/tests/SDK/Requests/PageRequestTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use RedberryProducts\MdNotion\SDK\Notion;
-use RedberryProducts\MdNotion\SDK\Requests\Actions\Page;
+use Redberry\MdNotion\SDK\Notion;
+use Redberry\MdNotion\SDK\Requests\Actions\Page;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
 

--- a/tests/SDK/Requests/QueryDataSourceRequestTest.php
+++ b/tests/SDK/Requests/QueryDataSourceRequestTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use RedberryProducts\MdNotion\SDK\Notion;
-use RedberryProducts\MdNotion\SDK\Requests\Actions\QueryDataSource;
+use Redberry\MdNotion\SDK\Notion;
+use Redberry\MdNotion\SDK\Requests\Actions\QueryDataSource;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
 

--- a/tests/Services/BlockRegistryTest.php
+++ b/tests/Services/BlockRegistryTest.php
@@ -1,13 +1,13 @@
 <?php
 
-use RedberryProducts\MdNotion\Adapters\BlockAdapterFactory;
-use RedberryProducts\MdNotion\SDK\Notion;
-use RedberryProducts\MdNotion\Services\BlockRegistry;
+use Redberry\MdNotion\Adapters\BlockAdapterFactory;
+use Redberry\MdNotion\SDK\Notion;
+use Redberry\MdNotion\Services\BlockRegistry;
 
 test('block registry resolves adapter correctly', function () {
     $notion = new Notion('test-key', '2022-06-28');
     $adapterMap = [
-        'paragraph' => \RedberryProducts\MdNotion\Adapters\ParagraphAdapter::class,
+        'paragraph' => \Redberry\MdNotion\Adapters\ParagraphAdapter::class,
     ];
 
     $factory = new BlockAdapterFactory($notion, $adapterMap);
@@ -15,14 +15,14 @@ test('block registry resolves adapter correctly', function () {
 
     $adapter = $registry->resolve('paragraph');
 
-    expect($adapter)->toBeInstanceOf(\RedberryProducts\MdNotion\Adapters\ParagraphAdapter::class);
+    expect($adapter)->toBeInstanceOf(\Redberry\MdNotion\Adapters\ParagraphAdapter::class);
 });
 
 test('block registry returns registered block types', function () {
     $notion = new Notion('test-key', '2022-06-28');
     $adapterMap = [
-        'paragraph' => \RedberryProducts\MdNotion\Adapters\ParagraphAdapter::class,
-        'heading_1' => \RedberryProducts\MdNotion\Adapters\HeadingAdapter::class,
+        'paragraph' => \Redberry\MdNotion\Adapters\ParagraphAdapter::class,
+        'heading_1' => \Redberry\MdNotion\Adapters\HeadingAdapter::class,
     ];
 
     $factory = new BlockAdapterFactory($notion, $adapterMap);

--- a/tests/Services/DatabaseReaderTest.php
+++ b/tests/Services/DatabaseReaderTest.php
@@ -1,9 +1,9 @@
 <?php
 
-use RedberryProducts\MdNotion\Objects\Database;
-use RedberryProducts\MdNotion\SDK\Notion;
-use RedberryProducts\MdNotion\Services\DatabaseReader;
-use RedberryProducts\MdNotion\Services\DatabaseTable;
+use Redberry\MdNotion\Objects\Database;
+use Redberry\MdNotion\SDK\Notion;
+use Redberry\MdNotion\Services\DatabaseReader;
+use Redberry\MdNotion\Services\DatabaseTable;
 
 test('database reader can be instantiated', function () {
     $notion = new Notion('test-key', '2022-06-28');

--- a/tests/Services/DatabaseTableBasicTest.php
+++ b/tests/Services/DatabaseTableBasicTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use RedberryProducts\MdNotion\SDK\Notion;
-use RedberryProducts\MdNotion\Services\DatabaseTable;
+use Redberry\MdNotion\SDK\Notion;
+use Redberry\MdNotion\Services\DatabaseTable;
 
 test('database table can be instantiated', function () {
     $notion = new Notion('test-key', '2022-06-28');

--- a/tests/Services/IntegrationTest.php
+++ b/tests/Services/IntegrationTest.php
@@ -1,9 +1,9 @@
 <?php
 
-use RedberryProducts\MdNotion\Objects\Database;
-use RedberryProducts\MdNotion\Objects\Page;
-use RedberryProducts\MdNotion\Services\DatabaseReader;
-use RedberryProducts\MdNotion\Services\PageReader;
+use Redberry\MdNotion\Objects\Database;
+use Redberry\MdNotion\Objects\Page;
+use Redberry\MdNotion\Services\DatabaseReader;
+use Redberry\MdNotion\Services\PageReader;
 
 test('page object can use page reader methods', function () {
     $page = new Page(['id' => 'test-page-id']);

--- a/tests/Services/PageReaderTest.php
+++ b/tests/Services/PageReaderTest.php
@@ -1,9 +1,9 @@
 <?php
 
-use RedberryProducts\MdNotion\Adapters\BlockAdapterFactory;
-use RedberryProducts\MdNotion\SDK\Notion;
-use RedberryProducts\MdNotion\Services\BlockRegistry;
-use RedberryProducts\MdNotion\Services\PageReader;
+use Redberry\MdNotion\Adapters\BlockAdapterFactory;
+use Redberry\MdNotion\SDK\Notion;
+use Redberry\MdNotion\Services\BlockRegistry;
+use Redberry\MdNotion\Services\PageReader;
 
 test('page reader can be instantiated', function () {
     $notion = new Notion('test-key', '2022-06-28');
@@ -18,7 +18,7 @@ test('page reader can be instantiated', function () {
 test('page reader processes blocks correctly', function () {
     $notion = new Notion('test-key', '2022-06-28');
     $adapterMap = [
-        'paragraph' => \RedberryProducts\MdNotion\Adapters\ParagraphAdapter::class,
+        'paragraph' => \Redberry\MdNotion\Adapters\ParagraphAdapter::class,
     ];
     $factory = new BlockAdapterFactory($notion, $adapterMap);
     $registry = new BlockRegistry($factory);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace RedberryProducts\MdNotion\Tests;
+namespace Redberry\MdNotion\Tests;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Orchestra\Testbench\TestCase as Orchestra;
-use RedberryProducts\MdNotion\MdNotionServiceProvider;
+use Redberry\MdNotion\MdNotionServiceProvider;
 
 class TestCase extends Orchestra
 {
@@ -13,7 +13,7 @@ class TestCase extends Orchestra
         parent::setUp();
 
         Factory::guessFactoryNamesUsing(
-            fn (string $modelName) => 'RedberryProducts\\MdNotion\\Database\\Factories\\'.class_basename($modelName).'Factory'
+            fn (string $modelName) => 'Redberry\\MdNotion\\Database\\Factories\\'.class_basename($modelName).'Factory'
         );
     }
 


### PR DESCRIPTION
This pull request updates the package namespace from `RedberryProducts\MdNotion` to `Redberry\MdNotion` across the entire codebase and documentation. This change standardizes the naming to match the new package name and ensures consistency for autoloading, configuration, and usage examples. The update touches source files, configuration, documentation, and example scripts.

Namespace and autoloading updates:

* Changed all PHP namespaces from `RedberryProducts\MdNotion` to `Redberry\MdNotion` throughout source files, including adapters, DTOs, services, and facades. [[1]](diffhunk://#diff-cf8027f12b5b247528cacc19408d24bae26f9ee5116461215397f475cd97e418L3-R6) [[2]](diffhunk://#diff-073ba8f613174b33f033abcb65b78f4450c34b2e60881f81a0728ccd4d12d1adL3-R6) [[3]](diffhunk://#diff-9ffbdf19ac297eb718a919c75eacf1cc3b6705f739081012c30925157c203ef4L3-R3) [[4]](diffhunk://#diff-3cbb9f1129c931b8a3303e828efe2096a21e74c6f35f131d54061da716172baaL3-R5) [[5]](diffhunk://#diff-ae6d848e59c148df2ef8fc00c75e7a593469fbbfac5f53d712857f0641251c9fL3-R5) [[6]](diffhunk://#diff-2764aa139e06cfe6bed91d712da66bd9490a724df52832daa8090b2493f27490L3-R5) [[7]](diffhunk://#diff-5dc7630b38a458c0b13087461e802ce7adfaad010650865fd62d4ffe80b37e06L3-R5)
* Updated `composer.json` to use the new namespace for PSR-4 autoloading and Laravel service provider/alias configuration. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L34-R39) [[2]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L60-R63)

Configuration and adapter references:

* Updated all adapter class references in `config/md-notion.php` to use the new namespace.
* Updated adapter references in usage examples and documentation to reflect the new namespace. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L80-R81) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L553-R554)

Documentation and example scripts:

* Revised documentation (`README.md`, `mdnotion_prd.md`) to use the new namespace in code samples and instructions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L13-R13) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L126-R126) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L233-R233) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L282-R282) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L510-R510) [[6]](diffhunk://#diff-bc84dcb31b51eb424c1a178b5415ef8d1e6da910bf747435937fff59ea9d2474L28-R28)
* Updated all example scripts to use the new namespace in imports and usage. [[1]](diffhunk://#diff-0fae57aefb4c1e778718373ffce647f6e2531256920bcb179e32f061bc1b8746L26-R28) [[2]](diffhunk://#diff-5dec156dd701b8e28c9b8cff031da1f800c96d115034d91b160b0057ad3b6bf9L26-R28) [[3]](diffhunk://#diff-2c5216c48bf2f3d61d4cba6302b88c227f83421d64213ef605e5265f733da6ddL15-R20) [[4]](diffhunk://#diff-9afb5ab8c55bc118a08e4c0a8cd77dc5e56ce3537deef240a85e2580db900c79L5-R5) [[5]](diffhunk://#diff-60bf426dfc8315f34219182847b74c9b94cadf78087ae1d3852dbd762f214bd1L15-R15) [[6]](diffhunk://#diff-60bf426dfc8315f34219182847b74c9b94cadf78087ae1d3852dbd762f214bd1L59-R59) [[7]](diffhunk://#diff-82f81e137b70f07103ea7a47f66261df15613d34ac0d4c091a6d6a6417b8f08aL15-R15) [[8]](diffhunk://#diff-82f81e137b70f07103ea7a47f66261df15613d34ac0d4c091a6d6a6417b8f08aL59-R59) [[9]](diffhunk://#diff-7413d6453f901e939bbd840c8f0d1c7b20c2ca0e7f71741e4e07c6cf036f16c0L5-R5) [[10]](diffhunk://#diff-9159f36fb451d0ae80735a2ce905d12ab1337b2625e3518c69858b9e407a18e8L15-R15) [[11]](diffhunk://#diff-9159f36fb451d0ae80735a2ce905d12ab1337b2625e3518c69858b9e407a18e8L59-R59)

Other updates:

* Updated test suite name in `phpunit.xml.dist` to match the new package name.
* Updated package keywords and comments to reflect the new name. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L5-R5) [[2]](diffhunk://#diff-fd1029f9c64391c8f11892d3d9a5ff5dcc72f7a20c07506d8cd1c7bbe4b5cf93L3-R3)

These changes ensure all references are consistent with the new package namespace, reducing confusion and potential autoloading issues.