### PR TITLE
Bump saloonphp/saloon dependency from ^3.14 to ^4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.3",
         "illuminate/contracts": "^11.0||^12.0",
-        "saloonphp/saloon": "^3.14",
+        "saloonphp/saloon": "^4.0",
         "spatie/laravel-package-tools": "^1.16"
     },
     "require-dev": {


### PR DESCRIPTION
This pull request updates the `saloonphp/saloon` dependency in the `composer.json` file to the latest major version, ensuring security, compatibility with new features and improvements.

* Dependency update:
  * Upgraded `saloonphp/saloon` from version `^3.14` to `^4.0` in `composer.json`, preparing the project for the latest changes in the Saloon library.